### PR TITLE
Do a non-prod npm install for the build image

### DIFF
--- a/docker/pnpm/Dockerfile
+++ b/docker/pnpm/Dockerfile
@@ -9,6 +9,7 @@ FROM base AS prod-deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
 
 FROM base AS build
+RUN pnpm install
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run -r build
 


### PR DESCRIPTION
Without this, tsc is not available and the next
`pnpm run -r build` step will fail.