### PR TITLE
Name docker frontend rule something non-generic

### DIFF
--- a/docker-compose.instructure.traefik.yml
+++ b/docker-compose.instructure.traefik.yml
@@ -13,7 +13,7 @@ services:
   frontend:
     labels:
       - traefik.enable=true
-      - "traefik.http.routers.frontend.rule=Host(`yaltt.inst.test`)"
+      - "traefik.http.routers.yalttfrontend.rule=Host(`yaltt.inst.test`)"
     networks:
       default:
         aliases:


### PR DESCRIPTION
The name of the routing rule apparently has to be unique -- I was using
this and the other LTI 1.3 test tool and they clobbered each other until
I renamed one.
