### PR TITLE
Add key for privacy_level config attribute

### DIFF
--- a/packages/lti-model/src/registration/LtiToolConfiguration.ts
+++ b/packages/lti-model/src/registration/LtiToolConfiguration.ts
@@ -23,6 +23,7 @@ export const LtiToolConfiguration = pipe(
     "https://canvas.instructure.com/lti/disable_reinstall": S.optional(
       S.boolean
     ),
+    "https://canvas.instructure.com/lti/privacy_level": S.optional(S.string),
   }),
   S.extend(LocalizedKeyOp("description"))
 );


### PR DESCRIPTION
Not sure if this is necessary or if somehow I missed a build step. I'm getting an error when I do `pnpm build @yaltt/backend` without this. It throws an error in mkYalttToolConfiguration.ts on line 62, saying that this property is not specified.

I can make it more specific that just a string if you'd like, I was just trying to get it working again here.